### PR TITLE
Add ticket availability checker

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,19 @@
-# caravaggio
-caravaggio 2025 rome
+# Caravaggio Ticket Monitor
+
+A simple script to check when tickets for the Caravaggio event in Rome become available.
+
+## Usage
+
+Install dependencies:
+
+```bash
+pip install -r requirements.txt
+```
+
+Run the script:
+
+```bash
+python ticket_monitor.py
+```
+
+The script fetches the event page and prints a message indicating whether tickets might be available.

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+requests
+beautifulsoup4

--- a/ticket_monitor.py
+++ b/ticket_monitor.py
@@ -1,0 +1,29 @@
+import requests
+from bs4 import BeautifulSoup
+
+URL = "https://caravaggio.coopculture.it/index.php?option=com_snapp&view=event&id=E2BE2FD9-64E4-5D37-412E-0194603DC454&catalogid=99786C19-0560-A43D-591F-019712AF59E4&lang=it"
+HEADERS = {"User-Agent": "Mozilla/5.0"}
+
+UNAVAILABLE_TEXTS = [
+    "posti esauriti",
+    "sold out",
+    "non disponibile",
+]
+
+def check_availability():
+    try:
+        response = requests.get(URL, headers=HEADERS)
+        response.raise_for_status()
+    except Exception as e:
+        print(f"Request failed: {e}")
+        return False
+
+    soup = BeautifulSoup(response.text, 'html.parser')
+    text = soup.get_text(separator=' ').lower()
+    return not any(phrase in text for phrase in UNAVAILABLE_TEXTS)
+
+if __name__ == "__main__":
+    if check_availability():
+        print("Tickets might be available!")
+    else:
+        print("Tickets not available yet.")


### PR DESCRIPTION
## Summary
- add `ticket_monitor.py` with a simple checker for ticket availability
- document the script in `README.md`
- add Python dependencies

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68423adc3c94832d84d87775f00cd674