### PR TITLE
Add integration tests for ticket monitor

### DIFF
--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -1,0 +1,29 @@
+import os
+import runpy
+import sys
+from unittest.mock import Mock
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
+import ticket_monitor
+
+
+def fake_response(text):
+    response = Mock()
+    response.text = text
+    response.raise_for_status = Mock()
+    return response
+
+
+def test_sold_out_message(monkeypatch, capsys):
+    monkeypatch.setattr('requests.get', lambda *args, **kwargs: fake_response('tickets SOLD OUT here'))
+    runpy.run_module('ticket_monitor', run_name='__main__')
+    captured = capsys.readouterr()
+    assert 'Tickets not available yet.' in captured.out
+
+
+def test_tickets_available_message(monkeypatch, capsys):
+    html = '<html><body>tickets are open now</body></html>'
+    monkeypatch.setattr('requests.get', lambda *args, **kwargs: fake_response(html))
+    runpy.run_module('ticket_monitor', run_name='__main__')
+    captured = capsys.readouterr()
+    assert 'Tickets might be available!' in captured.out


### PR DESCRIPTION
## Summary
- add integration tests verifying ticket monitor output using mocked HTTP responses

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68423b6093a8832da31d40a89a923ba4